### PR TITLE
翻译 Bracket_CreativeTab.md

### DIFF
--- a/docs/Vanilla/Brackets/Bracket_CreativeTab.md
+++ b/docs/Vanilla/Brackets/Bracket_CreativeTab.md
@@ -1,8 +1,8 @@
-# Creative Tab Bracket Handler
+# 创造模式物品栏选项卡处理器
 
-The Creative Tab Bracket Handler gives you access to the creative Tabs in the game. 
+创造模式物品栏标签页允许你访问游戏中的创造模式物品栏选项卡。
 
-They are referenced in the Creative Tab handler this way:
+可以用以下方式引用它们：
 
 ```
 <creativetab:name>
@@ -10,5 +10,5 @@ They are referenced in the Creative Tab handler this way:
 <creativetab:misc>
 ```
 
-If the Creative Tab is found, this will return an ICreativeTab Object.
-Please refer to the [respective Wiki entry](/Vanilla/CreativeTabs/ICreativeTab) for further information on what you can do with these.
+如果创造模式物品栏被找到，将返回ICreativeTab对象。
+更多使用它的信息可以参考[创造模式物品栏](/Vanilla/CreativeTabs/ICreativeTab)。


### PR DESCRIPTION
creative tab 是指创造模式物品栏的选项卡而不是指整个物品栏，因此网页左边一栏的翻译也需要更改，所以问下能在哪里找到。还有您最好能看下关联数组这一页面，翻译严重不统一，希望能使相同意思的相同单词能够翻译一致。