### PR TITLE
翻译 Recipes_Crafting_Table.md

### DIFF
--- a/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
+++ b/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
@@ -68,13 +68,15 @@ recipes.removeShapeless(output, inputs, wildcard);
 recipes.removeAll()`
 ```
 
-### Remove by name
-As 1.12 introduces naming recipes, you can also remove recipes once you know their name.
-You can also use regex to remove multiple recipes at once. And no, if you don't know what regular expressions are, I won't explain it here!
+### Remove by name（使用名称移除）
+由于1.12可以给合成命名，如果你知道了合成的名称也可以通过它以移除合成。
+你也可以用正则表达式一次移除多个合成。就算你不懂普通表达式的话，我也不会在这里解释！
 
 ```java
 recipes.removeByRegex("name[1-9]");
+//使用通配符移除合成
 recipes.removeByRecipeName("name123");
+//使用合成名称移除合成
 ```
 
 

--- a/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
+++ b/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
@@ -83,7 +83,7 @@ recipes.removeByRecipeName("name123");
 ## 添加合成
 ### 1.12 提醒
 
-1.12版本中，每一个添加的合成都有一个独特的编号，只是因为forge开发团队希望这样。
+1.12版本中，每一个添加的合成都有一个独特的编号，因为forge开发团队希望这样。
 也就是说现在所有添加配方的函数在开头需要有一个不可省略的参数`name`。
 因此`recipe.addShaped(output,input);`会变为`recipe.addShaped(name,output,input);`  
 其他函数都保持一致。谨记`name`要求是独特的。

--- a/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
+++ b/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
@@ -12,56 +12,58 @@ Mirrored Recipes是一种有序合成。唯一的区别是合成表可以沿水�
 
 ### 无序合成
 无序合成是指只有放入合成槽的物品影响合成的物品的合成。摆放的位置并不重要。
-For example, blue and yellow dye create green dye. This recipe doesn't care about where you put which item.例：蓝色染料和黄色染料可以合成绿色染料。这个配方不需要将物品放在特定的位置。
+例：青金石和骨粉可以合成淡蓝色染料。这个配方不需要将物品放在特定的位置。
 
 
-## Remove Recipes
-There are several ways of removing recipes.
+## 移除合成
+有多种方式可以移除合成。
 
 
-### remove
+### remove（移除配方）
 ```Java
 recipes.remove(output, NBTMatch);
 ```
 
-This will crafting table recipes for the given `output`.  
-If `NBTMatch`  is true, it will only remove recipes that result in items with the same NTB-Data as provided
+移除以此物品为`output（输出）`的合成。
+如果`NBTMatch（匹配NBT数据）`设置为true，则仅移除输出为与传入的NBT数据相同的物品的配方
 
-`Output` is an [IIngredient](/Vanilla/Variable_Types/IIngredient).  
-`NBTMatch` is a boolan and optional (Will be the same as false if not specified).
+`Output（输出）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)。 
+`NBTMatch（匹配NBT数据）` 类型为布尔值。它是可选参数（没有指明则默认为False)。
 
 
-### removeShaped
+### removeShaped（移除有序合成配方）
 ```Java
 recipes.removeShaped(output, inputs);
+
 ```
+注：inputs为输入的物品的排列方式，本段简称输入
+这个方法比上一个方法对所移除的物品有更严格的要求。它只会移除用`input（输入）`合成`output（输出）`的有序合成配方
 
-This one is more strict on which recipes to remove and will only remove shaped recipes that craft `output` with `input`.
+`output（输出）` 类型为 [IIngredient](/Vanilla/Variable_Types/IIngredient)  
+`inputs（输入）` 类型为 [IIngredient](/Vanilla/Variable_Types/IIngredient)[][] (例：[[iron,iron,iron],[iron,null,iron],[iron,null,iron]])
 
-`output` is an [IIngredient](/Vanilla/Variable_Types/IIngredient)  
-`inputs` is an [IIngredient](/Vanilla/Variable_Types/IIngredient)[][] (e.g.[[iron,iron,iron],[iron,null,iron],[iron,null,iron]])
-
-Furthermore, `inputs` is optional. If omitted, the function will do the same as `recipe.remove`, though it will only remove shaped Recipes.  
-`inputs` can contain wildcard characters: `[[<*>,<*>,<*>],[<*>,<*>,<*>],[<*>,<*>,<*>]]` would refer a recipe whose items, as long as each slot is filled, don't matter.
+此外`inputs（输入）`是可选参数。如果省略此参数，它除了只会移除有序合成的配方以外和`recipe.remove`功能相同。
+`inputs（输入）`可以包含通配符。例如 `[[<*>,<*>,<*>],[<*>,<*>,<*>],[<*>,<*>,<*>]]`表示一个只要每一个槽有物品，而不论物品种类就可以用于合成的配方。 
 
 
-### removeShapeless
+### removeShapeless（移除无序合成配方）
 ```Java
 recipes.removeShapeless(output, inputs, wildcard);
 ```
 
-This one is more strict on which recipes to remove and will only remove shapeless recipes that craft `output` with `input`.  
-If `wildcard` is true, it will remove shapeless recipes that craft `output` with `input` and other, non-specified items (for example you could disable all shapeless recipe that contain, among others, Lapis as ingredient).
+注：inputs为所有输入的物品，本段简称输入
+这个方法比第一方法对所移除的物品有更严格的要求。它只会移除用`input（输入）`合成`output（输出）`的无序序合成配方
+如果`wildcard（通配符）`设置为true，将会移除使用`input（输入）`与其他未指明物品合成`output（输出）`的无序合成配方（例：你可以移除所有需要使用青金石的无序合成配方）
 
-`output` is an [IIngredient](/Vanilla/Variable_Types/IIngredient)  
-`inputs` is an [IIngredient](/Vanilla/Variable_Types/IIngredient)[]  
-`wildcard` is a boolan and optional (Will be the same as false if not specified)
+`output（输出）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)  
+`inputs（输入）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)[]  
+`wildcard（通配符）`类型为布尔值且为可选参数（为指明则为false）
 
-Furthermore, `inputs` is optional. If omitted, the function will do the same as `recipe.remove`, though it will only remove shapeless Recipes.
+此外`inputs（输入）`是可选参数。如果省略此参数，它除了只会移除无序合成的配方以外和`recipe.remove`功能相同。
 
-### removeAll
-Removes all crafting recipes in the game.  
-A bit overkill, don't you think?
+### removeAll（移除全部）
+移除游戏中所有的配方。
+是不是有点赶尽杀绝的意味？
 ```java
 recipes.removeAll()`
 ```

--- a/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
+++ b/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
@@ -1,18 +1,18 @@
-# Recipes
+# 工作台配方
 
-## Recipe Types
-There are several types of recipes:
+## 配方类型
+有以下几种配方类型:
 
-### Shaped Recipes
-Shaped Recipes are recipes, where it matters, which item goes into which slot.
-For example, you can't just arrange 7 iron ingots in any order to create iron leggings. The shape matters, thus it is a shaped recipe.
+### 有序合成
+有序合成是指一个物品需要放在特定槽的合成。
+例：你不能随意放置7个铁锭以合成铁护腿。由于摆放位置对被合成的物品有影响，因此这是一个有序合成。
 
 ### Mirrored Recipe
-Mirrored Recipes are shaped recipes. Only difference is that the recipe can be mirrored along the horizontal or vertical axes.
+Mirrored Recipes是一种有序合成。唯一的区别是合成表可以沿水平轴或垂直轴翻折。
 
-### Shapeless Recipes
-Shapeless Recipes are recipes, where only the items you put in the crafting grid matter, whereas the shape is of no importance.
-For example, blue and yellow dye create green dye. This recipe doesn't care about where you put which item.
+### 无序合成
+无序合成是指只有放入合成槽的物品影响合成的物品的合成。摆放的位置并不重要。
+For example, blue and yellow dye create green dye. This recipe doesn't care about where you put which item.例：蓝色染料和黄色染料可以合成绿色染料。这个配方不需要将物品放在特定的位置。
 
 
 ## Remove Recipes

--- a/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
+++ b/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
@@ -36,14 +36,14 @@ recipes.remove(output, NBTMatch);
 recipes.removeShaped(output, inputs);
 
 ```
-注：inputs为输入的物品的排列方式，本段简称输入
-这个方法比上一个方法对所移除的物品有更严格的要求。它只会移除用`input（输入）`合成`output（输出）`的有序合成配方
+
+这个方法比上一个方法对所移除的物品有更严格的要求。它只会移除用`input`合成`output`的有序合成配方
 
 `output（输出）` 类型为 [IIngredient](/Vanilla/Variable_Types/IIngredient)  
 `inputs（输入）` 类型为 [IIngredient](/Vanilla/Variable_Types/IIngredient)[][] (例：[[iron,iron,iron],[iron,null,iron],[iron,null,iron]])
 
-此外`inputs（输入）`是可选参数。如果省略此参数，它除了只会移除有序合成的配方以外和`recipe.remove`功能相同。
-`inputs（输入）`可以包含通配符。例如 `[[<*>,<*>,<*>],[<*>,<*>,<*>],[<*>,<*>,<*>]]`表示一个只要每一个槽有物品，而不论物品种类就可以用于合成的配方。 
+此外`inputs`是可选参数。如果省略此参数，它除了只会移除有序合成的配方以外和`recipe.remove`功能相同。
+`inputs`可以包含通配符。例如 `[[<*>,<*>,<*>],[<*>,<*>,<*>],[<*>,<*>,<*>]]`表示一个只要每一个槽有物品，而不论物品种类就可以用于合成的配方。 
 
 
 ### removeShapeless（移除无序合成配方）
@@ -51,15 +51,15 @@ recipes.removeShaped(output, inputs);
 recipes.removeShapeless(output, inputs, wildcard);
 ```
 
-注：inputs为所有输入的物品，本段简称输入
-这个方法比第一方法对所移除的物品有更严格的要求。它只会移除用`input（输入）`合成`output（输出）`的无序序合成配方
-如果`wildcard（通配符）`设置为true，将会移除使用`input（输入）`与其他未指明物品合成`output（输出）`的无序合成配方（例：你可以移除所有需要使用青金石的无序合成配方）
+
+这个方法比第一方法对所移除的物品有更严格的要求。它只会移除用`input`合成`output`的无序序合成配方
+如果`wildcard`设置为true，将会移除使用`input`与其他未指明物品以合成`output`的无序合成配方（例：你可以移除所有需要使用青金石的无序合成配方）
 
 `output（输出）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)  
 `inputs（输入）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)[]  
 `wildcard（通配符）`类型为布尔值且为可选参数（为指明则为false）
 
-此外`inputs（输入）`是可选参数。如果省略此参数，它除了只会移除无序合成的配方以外和`recipe.remove`功能相同。
+此外`inputs`是可选参数。如果省略此参数，它除了只会移除无序合成的配方以外和`recipe.remove`功能相同。
 
 ### removeAll（移除全部）
 移除游戏中所有的配方。
@@ -70,7 +70,7 @@ recipes.removeAll()`
 
 ### Remove by name（使用名称移除）
 由于1.12可以给合成命名，如果你知道了合成的名称也可以通过它以移除合成。
-你也可以用正则表达式一次移除多个合成。就算你不懂普通表达式的话，我也不会在这里解释！
+你也可以用正则表达式一次移除多个合成。就算你不懂普通表达式，我也不会在这里解释！
 
 ```java
 recipes.removeByRegex("name[1-9]");
@@ -80,38 +80,37 @@ recipes.removeByRecipeName("name123");
 ```
 
 
-## Add Recipes
+## 添加合成
+### 1.12 提醒
 
-### Notes On 1.12
+1.12版本中，每一个添加的合成都有一个独特的编号，只是因为forge开发团队希望这样。
+也就是说现在所有添加配方的函数在开头需要有一个不可省略的参数`name`。
+因此`recipe.addShaped(output,input);`会变为`recipe.addShaped(name,output,input);`  
+其他函数都保持一致。谨记`name`要求是独特的。
+`name` 的类型为字符串。
 
-On 1.12, each added recipe requires a UNIQUE identifier, because the forge dev team wanted it that way.  
-This means, all add functions now require an additional parameter `name` at the start (which cannot be omitted).  
-This means `recipe.addShaped(output,input);` now is `recipe.addShaped(name,output,input);`  
-All other functionality stay the same. Remember that `name` needs to be unique!  
-`name` is a string.
-
-### addShaped
+### addShaped（添加有序合成）
 ```Java
-//pre-1.12
+//1.12之前
 recipes.addShaped(output,inputs,function,action);
 
 //1.12
 recipes.addShaped(name,output,inputs,function,action);
 ```
 
-This creates a shaped recipe for `output` using `inputs` as Ingredients.  
-If a `function` is added as third parameter, you can also use a function to determinate the output.  
-If an `action` function is added as forth parameter, you can also determine, what will happen, if the item is crafted.
+此方法将添加使用`input`合成`output`的有序合成配方
+如果`function`作为第三个被添加的参数，你还可以使用函数以判定产物。
+如果`action`函数作为第四个被添加的参数，你还可以决定当物品被合成时触发的事件。
 
-`name` is a string and needs to be unique but is also optional
-`output` is an [IItemStack](/Vanilla/Items/IItemStack)  
-`inputs` is an [IIngredient](/Vanilla/Variable_Types/IIngredient)[][] (see below)  
-`function` is a IRecipeFunction. Please refer to the [respecting wiki entry](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipefunction) for more information on functions.  
-`action` is a IRecipeAction. Please refer to the [respecting wiki entry](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipeaction) for more information on actions.  
+`name（名称）` 类型为字符串且需要是独特的，但又是一个可选参数。
+`output（输出）`类型为[IItemStack](/Vanilla/Items/IItemStack)  
+`inputs（输入）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)[][] (见下)  
+`function（函数）`类型为IRecipeFunction。更多关于function的信息请参考[对应的wiki页面](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipefunction)。
+`action（功能）`类型为IRecipeAction。更多关于action的信息请参考[对应的wiki页面](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipeaction)。
 
-`inputs` is a 2 Dimensional [IIngredient](/Vanilla/Variable_Types/IIngredient) Array.  
-So the recipe for Iron Leggings would be written as `[[iron,iron,iron],[iron,null,iron],[iron,null,iron]]`  
-If that looks to confusing, try splitting the arrays up into one array per line
+`inputs`是一个二维[IIngredient（材料）](/Vanilla/Variable_Types/IIngredient)数组。  
+因此铁护腿的配方会被写成`[[iron,iron,iron],[iron,null,iron],[iron,null,iron]]`  
+如果它看着就太复杂，可以将数组分裂，使得每一行都有一个数组。
 ```Java
 val iron = <minecraft:iron_ingot>;
 val leggings = <minecraft:iron_leggings>;
@@ -122,36 +121,37 @@ recipes.addShaped("CTLeggings", leggings,
   [iron,null,iron]]);
 ```
 
-### addShapedMirrored
+### addShapedMirrored（添加镜像合成）
 ```Java
-//Normal pre 1.12 syntax
+//常规格式（1.12之前）
 recipes.addShapedMirrored(output,inputs,function,action);
 
-//Recommended 1.12 syntax
+//推荐在1.12使用的格式
 recipes.addShapedMirrored(name,output,inputs,function,action);
 ```
 
-Same as `addShaped`, only that the recipe created this way is a mirrored recipe.
+处理创建的配方是镜像合成以外，和`addShaped`没有区别。
 
 
-### addShapeless
+### addShapeless（添加无序合成）
 ```Java
-//Normal pre 1.12 syntax
+//常规格式（1.12之前）
 recipes.addShapeless(output,inputs,function,action)
 
-//Recommended 1.12 syntax
+//推荐在1.12使用的格式
 recipes.addShapeless(name,output,inputs,function,action)
 ```
 
-This creates a shapeless recipe for `output` using `inputs` as Ingredients.
-If a `function` is added as third parameter, you can also use a function to determinate the output.
-If an `action` function is added as forth parameter, you can also determine, what will happen, if the item is crafted.
 
-`name` is a string and needs to be unique
-`output` is an [IItemStack](/Vanilla/Items/IItemStack)  
-`inputs` is an [IIngredient](/Vanilla/Variable_Types/IIngredient)[]  (e.g. [<minecraft:dye:1>,<minecraft:dye:2>])  
-`function` is a IRecipeFunction. Please refer to the [respecting wiki entry](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipefunction) for more information on functions. This is optional.  
-`action` is a IRecipeAction. Please refer to the [respecting wiki entry](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipeaction) for more information on actions. This is optional.  
+此方法将添加一个使用`input`合成`output`的无序合成配方
+如果`function`作为第三个被添加的参数，你还可以使用函数以判定产物。
+如果`action`函数作为第四个被添加的参数，你还可以决定当物品被合成时触发的事件。
+
+`name（名称）` 类型为字符串且需要是独特的
+`output（输出）`类型为[IItemStack](/Vanilla/Items/IItemStack)  
+`inputs（输入）`类型为[IIngredient](/Vanilla/Variable_Types/IIngredient)[] (例 [<minecraft:dye:1>,<minecraft:dye:2>])  
+`function（函数）`类型为IRecipeFunction。更多关于function的信息请参考[对应的wiki页面](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipefunction)。它是可选参数。
+`action（功能）`类型为IRecipeAction。更多关于action的信息请参考[对应的wiki页面](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipeaction)。它是可选参数。
 
 
 ## Other Functionality

--- a/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
+++ b/docs/Vanilla/Recipes/Crafting/Recipes_Crafting_Table.md
@@ -154,23 +154,23 @@ recipes.addShapeless(name,output,inputs,function,action)
 `action（功能）`类型为IRecipeAction。更多关于action的信息请参考[对应的wiki页面](/Vanilla/Recipes/Crafting/Recipe_Functions#irecipeaction)。它是可选参数。
 
 
-## Other Functionality
+## 其他功能
 
-### Get all registered Crafting recipes.
-You can use this to get a [`List<ICraftingRecipe>`](/Vanilla/Recipes/Crafting/ICraftingRecipe) that contains ALL registered crafting recipes.  
+### 获取所有注册的配方
+你可以使用以下方法获取一个包含所有注册的配方[`<ICraftingRecipe>列表`](/Vanilla/Recipes/Crafting/ICraftingRecipe)
 ```
 recipes.all;
 ```
 
-### Get all recipes for a given IIngredient
-You can use this to get a [`List<ICraftingRecipe>`](/Vanilla/Recipes/Crafting/ICraftingRecipe) that contains ALL registered crafting recipes for the given [IIngredient](/Vanilla/Variable_Types/IIngredient).  
+### 获取所有以传入物品为材料的配方
+你可以使用以下方法获取一个[`<ICraftingRecipe>列表`](/Vanilla/Recipes/Crafting/ICraftingRecipe)，它包含所有以传入物品为[IIngredient（材料）](/Vanilla/Variable_Types/IIngredient)的配方。 
 ```
 //recipes.getRecipesFor(IIngredient ingredient);
 recipes.getRecipesFor(<minecraft:iron_ingot>);
 ```
 
-### Craft
-You can even craft from inside `recipes`! The function will return an [IItemStack](Vanilla/Items/IItemStack) or `null` depending if a recipe is found or not.
+### 合成
+你甚至可以在`配方`里合成！这个函数会返回一个[IItemStack（物品堆）](Vanilla/Items/IItemStack)或`null`，返回结果取决于一个配方是否被找到。
 
 ```
 //recipes.craft(IItemStack[][]content);


### PR DESCRIPTION
翻译到15行时发现一个问题：原文说蓝色和黄色染料可以合成绿色染料，但原版中并不存在这个合成，甚至都没有蓝色染料和绿色染料这两个物品。要不提交一个Pull Requset给原作者? 还有问下mirrored recipe怎么翻译，这个名称在Minecraft Wiki上没有任何相关的页面。要不暂定为镜像合成？